### PR TITLE
Add link to borgbench

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ USE AT YOUR OWN RISK!
 The preferred way is that you put a link to your own repository here:
 
 - https://github.com/sten0/btrfs-borg
+- https://github.com/dragetd/borgbench (benchmark of borg chunking settings vs. final size for different types of data)
 - (add your link above this line)
 
 If you prefer having the file here, make a pull request.

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ USE AT YOUR OWN RISK!
 
 The preferred way is that you put a link to your own repository here:
 
-- https://github.com/sten0/btrfs-borg
+- https://github.com/sten0/btrfs-borg (script to handle btrfs-snapshots and borg)
 - https://github.com/dragetd/borgbench (benchmark of borg chunking settings vs. final size for different types of data)
 - (add your link above this line)
 


### PR DESCRIPTION
Add link to https://github.com/dragetd/borgbench and add description for links.