### PR TITLE
Cron script with xdg desktop notifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,5 @@ The preferred way is that you put a link to your own repository here:
 - https://github.com/sten0/btrfs-borg (script to handle btrfs-snapshots and borg)
 - https://github.com/dragetd/borgbench (benchmark of borg chunking settings vs. final size for different types of data)
 - https://github.com/mrkmg/borgbackup-zsh-completion (zsh completion for borg)
+- https://github.com/obilodeau/borgbackup-scripts (cron script with xdg desktop notifications)
 - (add your link above this line)
-
-If you prefer having the file here, make a pull request.
-
-Only files that have valid contact and license information will be accepted.
-
-Please keep the toplevel directory clean and put your stuff in a separate
-directory that just has your stuff.
-


### PR DESCRIPTION
Rationale: Whenever I am out of my network my backups will fail since the host is local (a CIFS mount). Desktops are not configured with an MTA so a backup cronjob that repetitively fails goes unnoticed.

This script which does desktop notifications helps to remind me to relaunch a backup manually whenever I get back to the office.