### PR TITLE
FEATURE: add borg-hive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Graphical front-ends
 
 - https://github.com/borgbase/vorta/ (Vorta – desktop client for Linux and macOS)
 - https://github.com/GaetanF/cyborgbackup (web-based user interface, REST API and task engine built on top of BorgBackup)
+- https://github.com/bpereto/borg-hive (web-based user interface for repositories and REST-API)
 
 Shell autocompletion
 --------------------


### PR DESCRIPTION
Hi,

I started a new opensource project to manage borgbackups. 

Why?
* Because I can
* It is fun doing this and challenging
* I don't want to keep it for myself.

The main goal of Borg Hive is to provide a easy management of borg repositories and ssh keys, also provide notifications if there is a stale backup. Optionally, it collects some events and statistics what’s happening.
It is similar to borgbase and cyborgbackup.
I backup my peripherals at home with borgbackup, which works nice on my servers, android phones, laptops, worktsations and so on. To keep the overview over my backups and which device haven’t done one in a while I decided to write a dashboard for it. The focus is for backups at home, but Borghive should also work in the cloud.

As i started the project, i missed that cyborgbackup exists, and has a similar technology stack and goal, althrough it controls and starts backups on server. the feature set for now is to manage repositories and monitor backups.

For the future, I think there could be a backup scheduling feature integrated with [AWX (ansible)](https://github.com/ansible/awx), to execute & orchestrate backups.

At the moment its in a development stage, but I'm using it already.
