### PR TITLE
Add Borg Backup Server to Graphical front-ends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Graphical front-ends
 - https://apps.apple.com/app/borglens/id6743801028 (BorgLens: Securely access your Borg backup — anywhere, anytime on iPhone and iPad)
 - https://github.com/mlapaglia/Borgitory (Web UI for managing BorgBackup repositories with scheduling, monitoring, and cloud sync)
 - https://github.com/karanhudia/borg-ui (Borg Web UI – Modern web interface for managing BorgBackup with scheduling, real-time progress tracking, and Docker deployment)
+- https://github.com/marcpope/borgbackupserver (Borg Backup Server – Self-hosted web GUI and centralized management dashboard for multi-server BorgBackup with agent-based architecture, scheduling, and file-level restore)
 
 Shell autocompletion
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Graphical front-ends
 - https://apps.apple.com/app/borglens/id6743801028 (BorgLens: Securely access your Borg backup — anywhere, anytime on iPhone and iPad)
 - https://github.com/mlapaglia/Borgitory (Web UI for managing BorgBackup repositories with scheduling, monitoring, and cloud sync)
 - https://github.com/karanhudia/borg-ui (Borg Web UI – Modern web interface for managing BorgBackup with scheduling, real-time progress tracking, and Docker deployment)
-- https://github.com/marcpope/borgbackupserver (Borg Backup Server – Self-hosted web GUI and centralized management dashboard for multi-server BorgBackup with agent-based architecture, scheduling, and file-level restore)
+- https://github.com/marcpope/borgbackupserver (Borg Backup Server – Self-hosted web GUI and centralized management dashboard for multi-client BorgBackup with agent-based architecture, scheduling, and file-level restore)
 
 Shell autocompletion
 --------------------


### PR DESCRIPTION
Adds [Borg Backup Server](https://github.com/marcpope/borgbackupserver) to the Graphical front-ends section.

**Borg Backup Server** is a self-hosted web GUI and centralized management dashboard for BorgBackup. Key features:

- **Agent-based architecture** — a lightweight Python agent on each client (Linux, macOS, Windows) polls the server for work; the server never SSHs into clients
- **Multi-server management** — schedule, monitor, and restore backups across all your servers from a single web interface
- **Backup scheduling** with cron support and retention policies
- **File-level restore** and full archive downloads from the web UI
- **Database backup plugins** (MySQL, PostgreSQL)
- **SSH append-only mode** for immutable backups
- **S3 offsite replication** (AWS, Wasabi, Backblaze B2)
- **Remote storage providers** — BorgBase, Hetzner Storage Box, rsync.net, or any SSH host

Website: https://www.borgbackupserver.com
Live demo: https://www.borgbackupserver.com/#demo
License: MIT